### PR TITLE
[!!!][UPDATE] Make extension compatible with TYPO3 v10

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -55,7 +55,7 @@ rldPage {
 }
 
 # Include jQuery. Assumes "page" as name for top level PAGE Object
-[globalVar = LIT:1 = {$plugin.tx_mediaconsent.settings.loadJQuery}]
+[{$plugin.tx_mediaconsent.settings.loadJQuery} == 1]
 page.includeJSFooterlibs.jquery = EXT:mediaconsent/Resources/Public/js/jquery.min.js
 [end]
 

--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ It is useful for embedding HTML snippets (often called widgets) from social medi
 
 The extension provides a new content element called "Media Consent Opt-In" which has two specific fields: one for the HTML snippet embedding the content, another for selecting the content provider (Facebook, Twitter...)
 
+## Routing
+
+To make the extension work with TYPO3's new routing, you should add a page type suffix for the reload page type, similar to this example:
+
+```
+routeEnhancers:
+  PageTypeSuffix:
+    map:
+      mediaconsent.html: 122
+```

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "typo3/cms-core": ">=8.7.8  <=10.4.99"
+        "typo3/cms-core": ">=9.5.0  <=10.4.99"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "typo3/cms-core": ">=8.7.8  <=9.5.99"
+        "typo3/cms-core": ">=8.7.8  <=10.4.99"
     },
     "autoload": {
         "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '0.1.7',
     'constraints' => [
         'depends' => [
-            'typo3' => '8.7.8-9.5.99',
+            'typo3' => '8.7.8-10.4.99',
         ]
     ]
 ];

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '0.1.7',
     'constraints' => [
         'depends' => [
-            'typo3' => '8.7.8-10.4.99',
+            'typo3' => '9.5.0-10.4.99',
         ]
     ]
 ];


### PR DESCRIPTION
Hi,

first of all thanks for your extension.

I have a TYPO3 10 project and wanted to use your extension. So I just installed it and made it work for my needs. The only change I had to to was to update tp the new condition syntax, which was introduced in TYPO3 v9. So I had to remove the compatibility with TYPO3 8 LTS.