### PR TITLE
[BUGFIX] Avoid <html> tags being rendered

### DIFF
--- a/Resources/Private/Partials/Header.html
+++ b/Resources/Private/Partials/Header.html
@@ -1,4 +1,4 @@
-<html xmlns:mcse="http://ekvw.de/mcse">
+<html xmlns:mcse="http://ekvw.de/mcse" data-namespace-typo3-fluid="true">
 <f:switch expression="{data.header_layout}">
 	<f:case value="0">
 		<h1>

--- a/Resources/Private/Templates/Mediaconsent_cns.html
+++ b/Resources/Private/Templates/Mediaconsent_cns.html
@@ -1,4 +1,4 @@
-<html xmlns:mcse="http://ekvw.de/mcse">
+<html xmlns:mcse="http://ekvw.de/mcse" data-namespace-typo3-fluid="true">
 
 <div class="mediaconsent_element">
     <f:if condition="{wrapperActive} = 1">


### PR DESCRIPTION
Hi,

I realized, the `<html>` tags of the extension's template and partial are rendered to frontend. So I added the missing `data-namespace-typo3-fluid="true"` attribute.

| Before | After |
| --- | --- |
| ![Bildschirmfoto 2020-06-08 um 21 10 42](https://user-images.githubusercontent.com/16088567/84070798-fd851000-a9cc-11ea-9d41-da4544aea341.png) | ![Bildschirmfoto 2020-06-08 um 21 11 28](https://user-images.githubusercontent.com/16088567/84070793-fcec7980-a9cc-11ea-98cf-fc98e91fe504.png) |
