### PR TITLE
[UPDATE] Make extension compatible with TYPO3 v11

### DIFF
--- a/Resources/Private/Templates/Mediaconsent_cns.html
+++ b/Resources/Private/Templates/Mediaconsent_cns.html
@@ -12,7 +12,7 @@
 </div>
 
 <f:section name="showWrapper">
-    <div class="mediaconsent_wrapper" data-mcuri="{f:uri.page(pageType: pageType, additionalParams: {mediaconsent_item: data.uid}, noCacheHash: 1)}" data-mctype="{data.mediaconsent_smcprovider}">
+    <div class="mediaconsent_wrapper" data-mcuri="{f:uri.page(pageType: pageType, additionalParams: {mediaconsent_item: data.uid})}" data-mctype="{data.mediaconsent_smcprovider}">
         <f:render partial="Header" arguments="{data: data}" />
         <input type="checkbox" name="mcb{smcProvider}">
         <f:if condition="{data.mediaconsent_smcprovider} != 7">

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "typo3/cms-core": ">=9.5.0  <=10.4.99"
+        "typo3/cms-core": "^9.5 || ^10 || ^11"
     },
     "autoload": {
         "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '0.1.8',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5.0-10.4.99',
+            'typo3' => '9.5.0-11.5.99',
         ]
     ]
 ];


### PR DESCRIPTION
I upgraded my v10 project to v11 and wanted to keep this extension. So I started to make it compatible to TYPO3 v11 which was very easy this time: nearly no breaking changes, I simply updated the requirements and installed it. After that I had to remove the `noCacheHash` property from a viewhelper and that seems to be all.

The `noCacheHash` property was [deprecated since TYPO3 10](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.0/Deprecation-88406-SetCacheHashnoCacheHashOptionsInViewHelpersAndUriBuilder.html) and was removed in TYPO3 11

It would be great if you could merge this and do one more release for this extension. 